### PR TITLE
Inline Resend env vars at build time for Amplify SSR runtime

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+    env: {
+        RESEND_API_KEY: process.env.RESEND_API_KEY,
+        RESEND_AUDIENCE_ID: process.env.RESEND_AUDIENCE_ID,
+    },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Add `env` config to `next.config.ts` to inline `RESEND_API_KEY` and `RESEND_AUDIENCE_ID` at build time
- Fixes env vars not being available at runtime in Amplify's SSR Lambda

## Test plan
- [ ] Deploy to Amplify and verify newsletter subscription works
- [ ] Confirm contact appears in Resend audience after subscribing


Made with [Cursor](https://cursor.com)