### PR TITLE
Prevent duplicate subscribe notifications and add spam protection

### DIFF
--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,10 +1,50 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 
-const NOTIFICATION_EMAIL = `liati.business@gmail.com`;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 3;
+const rateLimitMap = new Map<string, number[]>();
+
+function isRateLimited(ip: string): boolean {
+    const now = Date.now();
+    const timestamps = rateLimitMap.get(ip) ?? [];
+    const recent = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+
+    if (recent.length >= RATE_LIMIT_MAX_REQUESTS) {
+        rateLimitMap.set(ip, recent);
+        return true;
+    }
+
+    recent.push(now);
+    rateLimitMap.set(ip, recent);
+    return false;
+}
+
+setInterval(() => {
+    const now = Date.now();
+    for (const [ip, timestamps] of rateLimitMap) {
+        const recent = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+        if (recent.length === 0) {
+            rateLimitMap.delete(ip);
+        } else {
+            rateLimitMap.set(ip, recent);
+        }
+    }
+}, 60_000);
 
 export async function POST(request: NextRequest) {
     try {
+        const ip = request.headers.get(`x-forwarded-for`)?.split(`,`)[0].trim()
+            ?? request.headers.get(`x-real-ip`)
+            ?? `unknown`;
+
+        if (isRateLimited(ip)) {
+            return NextResponse.json(
+                { error: `Too many attempts. Please try again in a minute.` },
+                { status: 429 }
+            );
+        }
+
         const apiKey = process.env.RESEND_API_KEY;
         const audienceId = process.env.RESEND_AUDIENCE_ID;
 
@@ -19,7 +59,14 @@ export async function POST(request: NextRequest) {
         const resend = new Resend(apiKey);
 
         const body = await request.json();
-        const { email } = body;
+        const { email, website } = body;
+
+        if (website) {
+            return NextResponse.json(
+                { message: `Successfully subscribed!` },
+                { status: 200 }
+            );
+        }
 
         if (!email || typeof email !== `string`) {
             return NextResponse.json(
@@ -36,39 +83,40 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        const { error: contactError } = await resend.contacts.create({
-            email,
-            audienceId: audienceId,
+        const { data: listData, error: listError } = await resend.contacts.list({
+            audienceId,
         });
 
-        if (contactError) {
-            if (contactError.message?.toLowerCase().includes(`already exists`)) {
-                return NextResponse.json(
-                    { error: `This email is already subscribed` },
-                    { status: 409 }
-                );
-            }
-            console.error(`Resend contact error:`, contactError);
+        if (listError) {
+            console.error(`Resend list contacts error:`, listError);
             return NextResponse.json(
                 { error: `Failed to subscribe. Please try again.` },
                 { status: 500 }
             );
         }
 
-        try {
-            await resend.emails.send({
-                from: `LIATI Newsletter <onboarding@resend.dev>`,
-                to: NOTIFICATION_EMAIL,
-                subject: `New Newsletter Subscriber`,
-                html: `
-                    <h2>New Newsletter Subscriber</h2>
-                    <p>A new user has subscribed to the LIATI newsletter:</p>
-                    <p><strong>Email:</strong> ${email}</p>
-                    <p><strong>Date:</strong> ${new Date().toLocaleString()}</p>
-                `,
-            });
-        } catch (emailError) {
-            console.error(`Notification email failed (non-blocking):`, emailError);
+        const alreadySubscribed = listData?.data?.some(
+            (contact) => contact.email.toLowerCase() === email.toLowerCase()
+        );
+
+        if (alreadySubscribed) {
+            return NextResponse.json(
+                { message: `You've already subscribed, thanks!` },
+                { status: 200 }
+            );
+        }
+
+        const { error: contactError } = await resend.contacts.create({
+            email,
+            audienceId,
+        });
+
+        if (contactError) {
+            console.error(`Resend contact error:`, contactError);
+            return NextResponse.json(
+                { error: `Failed to subscribe. Please try again.` },
+                { status: 500 }
+            );
         }
 
         return NextResponse.json(

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -30,7 +30,10 @@ export default function Footer() {
             const res = await fetch(`/api/subscribe`, {
                 method: `POST`,
                 headers: { "Content-Type": `application/json` },
-                body: JSON.stringify({ email }),
+                body: JSON.stringify({
+                    email,
+                    website: (e.target as HTMLFormElement).querySelector<HTMLInputElement>(`[name="website"]`)?.value ?? ``,
+                }),
             });
 
             const data = await res.json();
@@ -133,6 +136,14 @@ export default function Footer() {
                             Subscribe for the latest fashion updates and exclusive offers.
                         </p>
                         <form onSubmit={handleSubscribe} noValidate className="space-y-3">
+                            <input
+                                type="text"
+                                name="website"
+                                autoComplete="off"
+                                tabIndex={-1}
+                                aria-hidden="true"
+                                className="absolute overflow-hidden w-0 h-0 opacity-0 pointer-events-none"
+                            />
                             <div className="flex flex-col sm:flex-row gap-2">
                                 <input
                                     type="email"


### PR DESCRIPTION
## Summary
- **Duplicate detection**: Checks existing Resend audience contacts before creating a new one. If the email is already subscribed, returns a friendly "You've already subscribed, thanks!" message instead of creating a duplicate or sending notifications.
- **Rate limiting**: Added in-memory IP-based rate limiter (3 requests per 60s window) to throttle abuse of the subscribe endpoint.
- **Honeypot field**: Added a hidden `website` input field to the footer form that catches bot submissions — bots that fill it get a fake success response.
- **Removed notification email**: Eliminated the `resend.emails.send()` call that notified `liati.business@gmail.com` on each new subscriber, removing Resend email quota usage entirely. New subscribers can be reviewed in the Resend audience dashboard.

## Test plan
- [ ] Subscribe with a new email — should succeed with "Successfully subscribed!"
- [ ] Subscribe again with the same email — should show "You've already subscribed, thanks!" with no side effects
- [ ] Submit the form rapidly (4+ times in under a minute) — 4th attempt should show "Too many attempts. Please try again in a minute."
- [ ] Verify the honeypot input is invisible in the rendered form
- [ ] Confirm no notification emails are sent to `liati.business@gmail.com`


Made with [Cursor](https://cursor.com)